### PR TITLE
Fix chat assistant task loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -1082,9 +1082,14 @@
       container.scrollTop = container.scrollHeight;
     }
 
-    // 3) Загружает список задач из localStorage
+    // 3) Загружает список задач из централизованных данных LifePlanner
     function loadTasks() {
-      return JSON.parse(localStorage.getItem("tasks") || "[]");
+      try {
+        return LifePlanner.getData().tasks || [];
+      } catch (e) {
+        // Fallback для старых данных, если LifePlanner недоступен
+        return JSON.parse(localStorage.getItem("tasks") || "[]");
+      }
     }
 
     // 4) Обработчик клика по кнопке отправки


### PR DESCRIPTION
## Summary
- Load chat assistant tasks from centralized LifePlanner data with fallback to legacy storage

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js && node --check planner.js`


------
https://chatgpt.com/codex/tasks/task_e_6899c86b4f888322a14e650a56eb05fb