### PR TITLE
chore: deduplicate saveData and unify storage key

### DIFF
--- a/script.js
+++ b/script.js
@@ -466,7 +466,7 @@ window.LifePlanner = (function() {
   let currentDate = new Date();
   currentDate.setHours(0, 0, 0, 0);
 
-  const LOCAL_STORAGE_KEY = 'lifeosData';
+  const LOCAL_STORAGE_KEY = 'lifeOSData';
 
   function loadData() {
       const savedData = localStorage.getItem(LOCAL_STORAGE_KEY);
@@ -489,11 +489,6 @@ window.LifePlanner = (function() {
 
   function saveData() {
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(data));
-  }
-
-  // --- Функции для задач ---
-  function saveData() {
-    localStorage.setItem('lifeOSData', JSON.stringify(data));
   }
 
   // Функция для расчета опыта, необходимого для следующего уровня (прогрессивная шкала)
@@ -785,6 +780,10 @@ document.addEventListener('DOMContentLoaded', function() {
     renderHealthLog();
     if (window.LifePlanner && typeof window.LifePlanner.init === 'function') {
         window.LifePlanner.init();
+        // Дополнительный вызов гарантирует, что задачи отрисуются сразу после загрузки
+        if (typeof window.LifePlanner.renderTasks === 'function') {
+            window.LifePlanner.renderTasks();
+        }
         console.log('LifePlanner инициализирован');
     }
     


### PR DESCRIPTION
## Summary
- remove duplicate saveData implementation and standardize on LOCAL_STORAGE_KEY
- ensure LifePlanner uses `lifeOSData` key consistently and render tasks on load

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_6899cab06fb4832298e30b46cf9ff4b9