### PR TITLE
feat: add global xp progress bar

### DIFF
--- a/script.js
+++ b/script.js
@@ -697,6 +697,9 @@ window.LifePlanner = (function() {
     dueDateInput.value = '';
     renderTasks();
     generateCalendar(currentDate.getFullYear(), currentDate.getMonth());
+    if (typeof updateRPGOverview === 'function') {
+      updateRPGOverview();
+    }
   }
   function renderTasks() {
     const taskList = document.getElementById('task-list');
@@ -737,6 +740,9 @@ window.LifePlanner = (function() {
         }
         saveData();
         renderTasks();
+        if (typeof updateRPGOverview === 'function') {
+          updateRPGOverview();
+        }
       });
       leftBlock.appendChild(checkbox);
       if (task.subTasks && task.subTasks.length > 0) {
@@ -1657,9 +1663,12 @@ function updateGamificationUI() {
   
   // Создаем сегменты для XP бара
   createXPSegments(xpForNextLevel);
-  
+
   // Обновляем подсказку
   updateXPTooltip(xp, xpForNextLevel, level);
+  if (typeof updateRPGXPBar === 'function') {
+    updateRPGXPBar();
+  }
 }
 
 // Функция для создания сегментов XP бара

--- a/style.css
+++ b/style.css
@@ -62,7 +62,7 @@
         body {
             font-family: 'RimWorld', 'Segoe UI', sans-serif;
             margin: 0;
-            padding: 0;
+            padding: 24px 0 0 0;
             background: #2E2E2E; /* Dark gray, common in RimWorld UI */
             color: #D1C7B7; /* Light beige/off-white text */
             font-size: 14px;
@@ -91,8 +91,12 @@
 
         /* Новая система XP прогресс-бара */
         .xp-container {
-            position: relative;
-            margin: 0.5rem 0;
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            margin: 0;
+            z-index: 1000;
         }
 
         .xp-bar-wrapper {


### PR DESCRIPTION
## Summary
- show global XP bar at top of screen
- refresh RPG overview when tasks complete to sync XP
- keep XP bar in sync with RPG panel updates

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689b567ca03c8322832a4a486db4e9bd