### PR TITLE
Render default dailies on init

### DIFF
--- a/planner.js
+++ b/planner.js
@@ -728,73 +728,6 @@ window.LifePlanner = (function() {
     data.medicalHistory = data.medicalHistory || [];
     data.dailies = data.dailies || [];
     
-    // Инициализируем дейлики по умолчанию, если их нет
-    if (!data.dailies || data.dailies.length === 0) {
-      data.dailies = [
-        {
-          id: 'daily_breakfast',
-          title: 'Позавтракать',
-          description: 'Съесть полноценный завтрак с белками и углеводами',
-          xp: 25,
-          icon: 'fas fa-utensils',
-          image: 'https://images.unsplash.com/photo-1494859802809-d069c3b71a8a?w=400&h=300&fit=crop',
-          completed: false,
-          completedDate: null
-        },
-        {
-          id: 'daily_teeth',
-          title: 'Почистить зубы',
-          description: 'Утренняя и вечерняя гигиена полости рта',
-          xp: 15,
-          icon: 'fas fa-toothbrush',
-          image: 'https://images.unsplash.com/photo-1559591935-c6c92c6c2b6e?w=400&h=300&fit=crop',
-          completed: false,
-          completedDate: null
-        },
-        {
-          id: 'daily_exercise',
-          title: 'Сделать зарядку',
-          description: 'Легкая физическая разминка для поддержания тонуса',
-          xp: 30,
-          icon: 'fas fa-dumbbell',
-          image: 'https://images.unsplash.com/photo-1571019613454-1cb2f99b2d8b?w=400&h=300&fit=crop',
-          completed: false,
-          completedDate: null
-        },
-        {
-          id: 'daily_water',
-          title: 'Выпить воды',
-          description: 'Поддерживать водный баланс организма',
-          xp: 10,
-          icon: 'fas fa-tint',
-          image: 'https://images.unsplash.com/photo-1559827260-dc66d52bef19?w=400&h=300&fit=crop',
-          completed: false,
-          completedDate: null
-        },
-        {
-          id: 'daily_reading',
-          title: 'Почитать книгу',
-          description: 'Развивать интеллект и расширять кругозор',
-          xp: 20,
-          icon: 'fas fa-book',
-          image: 'https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=400&h=300&fit=crop',
-          completed: false,
-          completedDate: null
-        },
-        {
-          id: 'daily_walk',
-          title: 'Прогуляться',
-          description: 'Свежий воздух и легкая физическая активность',
-          xp: 20,
-          icon: 'fas fa-walking',
-          image: 'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=300&fit=crop',
-          completed: false,
-          completedDate: null
-        }
-      ];
-      saveData();
-    }
-    
     // Навешиваем обработчики событий только после загрузки DOM
     const addTaskButton = document.getElementById('add-task');
     const newTaskInput = document.getElementById('new-task');
@@ -841,6 +774,10 @@ window.LifePlanner = (function() {
     
     // Сбрасываем дейлики на новый день, если нужно
     resetDailiesIfNewDay();
+
+    // Инициализируем и отображаем дейлики после загрузки данных
+    initializeDefaultDailies();
+    renderRPGDailies();
   }
   
   // Функция для сброса дейликов на новый день


### PR DESCRIPTION
## Summary
- Initialize default dailies and render RPG dailies after resetting for a new day so the grid shows on load.
- Remove inline default daily setup from `init` in favor of dedicated helpers.

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b5d9f3034832299db64c3d7228c89